### PR TITLE
Preventing manifest file to be added to Android library projects

### DIFF
--- a/Protobuild/BuildResources/GenerateProject.xslt
+++ b/Protobuild/BuildResources/GenerateProject.xslt
@@ -578,23 +578,23 @@
             <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
             <AndroidStoreUncompressedFileExtensions />
             <MandroidI18n />
-            <xsl:choose>
-              <xsl:when test="Input/Properties/ManifestPrefix">
-                <AndroidManifest>
-                  <xsl:value-of select="concat(
-                                '..\',
-                                $project/@Name,
-                                '.',
-                                /Input/Generation/Platform,
-                                '\Properties\AndroidManifest.xml')"/>
-                </AndroidManifest>
-              </xsl:when>
-              <xsl:otherwise>
-                <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-              </xsl:otherwise>
-            </xsl:choose>
             <DeployExternal>False</DeployExternal>
             <xsl:if test="$project/@Type = 'App'">
+              <xsl:choose>
+                <xsl:when test="Input/Properties/ManifestPrefix">
+                  <AndroidManifest>
+                    <xsl:value-of select="concat(
+                                  '..\',
+                                  $project/@Name,
+                                  '.',
+                                  /Input/Generation/Platform,
+                                  '\Properties\AndroidManifest.xml')"/>
+                  </AndroidManifest>
+                </xsl:when>
+                <xsl:otherwise>
+                  <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+                </xsl:otherwise>
+              </xsl:choose>
               <AndroidApplication>True</AndroidApplication>
               <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
               <AndroidResgenClass>Resource</AndroidResgenClass>


### PR DESCRIPTION
Hello,

Correct me if I am wrong, but android manifest for library projects are ignored by the android SDK. Only the application manifest is considered.

The only important setting for library projects is the target platform (see http://developer.android.com/tools/projects/index.html):

> Platform version must be lower than or equal to the Android project
> 
> A library is compiled as part of the dependent application project, so the API used in the library project must be compatible with the version of the Android library used to compile the application project. In general, the library project should use an API level that is the same as — or lower than — that used by the application. If the library project uses an API level that is higher than that of the application, the application project will not compile. It is perfectly acceptable to have a library that uses the Android 1.5 API (API level 3) and that is used in an Android 1.6 (API level 4) or Android 2.1 (API level 7) project, for instance.

The problem is that Protobuild binds a manifest file to the android projets. This is not really important because manifest are ignored, but it exposes the following behavior of Xamarin Studio / Visual Studio: http://community.monogame.net/t/embedding-openal-compilation-issue/779/10
(in short: adding a manifest to a library projects make it to be considered as an application by IDE's, sometimes preventing the project to be build unless the flag is removed of the csproj file).

This PR makes manifest files to be added only to 'app' projects.
