### PR TITLE
Allow only Any CPU on Windows Phone 8.1 Platform

### DIFF
--- a/Protobuild/BuildResources/GenerateProject.xslt
+++ b/Protobuild/BuildResources/GenerateProject.xslt
@@ -869,30 +869,6 @@
             <xsl:with-param name="config">Release</xsl:with-param>
             <xsl:with-param name="platform">AnyCPU</xsl:with-param>
           </xsl:call-template>
-          <xsl:call-template name="configuration">
-            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
-            <xsl:with-param name="debug">true</xsl:with-param>
-            <xsl:with-param name="config">Debug</xsl:with-param>
-            <xsl:with-param name="platform">x86</xsl:with-param>
-          </xsl:call-template>
-          <xsl:call-template name="configuration">
-            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
-            <xsl:with-param name="debug">false</xsl:with-param>
-            <xsl:with-param name="config">Release</xsl:with-param>
-            <xsl:with-param name="platform">x86</xsl:with-param>
-          </xsl:call-template>
-          <xsl:call-template name="configuration">
-            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
-            <xsl:with-param name="debug">true</xsl:with-param>
-            <xsl:with-param name="config">Debug</xsl:with-param>
-            <xsl:with-param name="platform">ARM</xsl:with-param>
-          </xsl:call-template>
-          <xsl:call-template name="configuration">
-            <xsl:with-param name="type"><xsl:value-of select="$project/@Type" /></xsl:with-param>
-            <xsl:with-param name="debug">false</xsl:with-param>
-            <xsl:with-param name="config">Release</xsl:with-param>
-            <xsl:with-param name="platform">ARM</xsl:with-param>
-          </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
           <xsl:call-template name="configuration">

--- a/Protobuild/BuildResources/GenerateSolution.xslt
+++ b/Protobuild/BuildResources/GenerateSolution.xslt
@@ -59,13 +59,11 @@
         GlobalSection(ProjectConfigurationPlatforms) = postSolution
 </xsl:text>
       </xsl:when>
-      <xsl:when test="/Input/Generation/Platform = 'WindowsPhone'">
+      <xsl:when test="/Input/Generation/Platform = 'WindowsPhone81'">
         <xsl:text>Global
         GlobalSection(SolutionConfigurationPlatforms) = preSolution
-                Debug|x86 = Debug|x86
-                Release|x86 = Release|x86
-                Debug|ARM = Debug|ARM
-                Release|ARM = Release|ARM
+                Debug|Any CPU = Debug|Any CPU
+                Release|Any CPU = Release|Any CPU
         EndGlobalSection
         GlobalSection(ProjectConfigurationPlatforms) = postSolution
 </xsl:text>
@@ -293,112 +291,6 @@ EndProject
 </xsl:text>
       </xsl:when>
       <xsl:when test="/Input/Generation/Platform = 'WindowsPhone'">
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Debug|x86.ActiveCfg = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$debug-mapping != ''">
-            <xsl:value-of select="$debug-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Debug|x86</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Debug|x86.Build.0 = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$debug-mapping != ''">
-            <xsl:value-of select="$debug-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Debug|x86</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Release|x86.ActiveCfg = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$release-mapping != ''">
-            <xsl:value-of select="$release-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Release|x86</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Release|x86.Build.0 = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$release-mapping != ''">
-            <xsl:value-of select="$release-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Release|x86</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Debug|ARM.ActiveCfg = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$debug-mapping != ''">
-            <xsl:value-of select="$debug-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Debug|ARM</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Debug|ARM.Build.0 = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$debug-mapping != ''">
-            <xsl:value-of select="$debug-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Debug|ARM</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Release|ARM.ActiveCfg = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$release-mapping != ''">
-            <xsl:value-of select="$release-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Release|ARM</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-        <xsl:text>                {</xsl:text>
-        <xsl:value-of select="$guid" />
-        <xsl:text>}.Release|ARM.Build.0 = </xsl:text>
-        <xsl:choose>
-          <xsl:when test="$release-mapping != ''">
-            <xsl:value-of select="$release-mapping" />
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:text>Release|ARM</xsl:text>
-          </xsl:otherwise>
-        </xsl:choose>
-        <xsl:text>
-</xsl:text>
-      </xsl:when>
-      <xsl:when test="/Input/Generation/Platform = 'WindowsPhone81'">
         <xsl:text>                {</xsl:text>
         <xsl:value-of select="$guid" />
         <xsl:text>}.Debug|x86.ActiveCfg = </xsl:text>


### PR DESCRIPTION
Removal of x86/arm on wp8.1 platform, and fix a misspelling bug on the solution definition file to allow only Any CPU arch.
