### PR TITLE
Remove hard-coded path to Mono in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,8 @@ parallel(
   "Mac": {
     node('mac') {
       checkout poll: false, changelog: false, scm: scm
-      sh ("/usr/local/bin/mono Protobuild.exe --upgrade-all")
-      sh ("/usr/local/bin/mono Protobuild.exe --automated-build")
+      sh ("mono Protobuild.exe --upgrade-all")
+      sh ("mono Protobuild.exe --automated-build")
     }
   },
   "Linux": {


### PR DESCRIPTION
Mono is now on the PATH for the build server, so removing this hard-coded path should fix other PRs (once they are rebased on top of it).